### PR TITLE
Two more changes for oauthconsumer

### DIFF
--- a/OAToken.h
+++ b/OAToken.h
@@ -40,6 +40,7 @@
 @property(retain, readwrite) NSString *secret;
 @property(retain, readwrite) NSString *session;
 @property(retain, readwrite) NSNumber *duration;
+@property(retain, readwrite) NSString *verifier;
 @property(retain, readwrite) NSDictionary *attributes;
 @property(readwrite, getter=isForRenewal) BOOL forRenewal;
 

--- a/OAToken.h
+++ b/OAToken.h
@@ -25,7 +25,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface OAToken : NSObject {
+@interface OAToken : NSObject <NSCoding> {
 @protected
 	NSString *key;
 	NSString *secret;

--- a/OAToken.m
+++ b/OAToken.m
@@ -68,6 +68,18 @@
 	return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+	OAToken *t = [self initWithKey:[aDecoder decodeObjectForKey:@"key"]
+							secret:[aDecoder decodeObjectForKey:@"secret"]
+						   session:[aDecoder decodeObjectForKey:@"session"]
+						  duration:[aDecoder decodeObjectForKey:@"duration"]
+						attributes:[aDecoder decodeObjectForKey:@"attributes"]
+						   created:[aDecoder decodeObjectForKey:@"created"]
+						 renewable:[aDecoder decodeBoolForKey:@"renewable"]];
+	[t setVerifier:[aDecoder decodeObjectForKey:@"verifier"]];
+	return t;
+}
+
 - (id)initWithHTTPResponseBody:(const NSString *)body {
     NSString *aKey = nil;
 	NSString *aSecret = nil;
@@ -149,6 +161,16 @@
 	
 	[[NSUserDefaults standardUserDefaults] synchronize];
 	return(0);
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+	[aCoder encodeObject:[self key] forKey:@"key"];
+	[aCoder encodeObject:[self secret] forKey:@"secret"];
+	[aCoder encodeObject:[self session] forKey:@"session"];
+	[aCoder encodeObject:[self duration] forKey:@"duration"];
+	[aCoder encodeObject:[self attributes] forKey:@"attributes"];
+	[aCoder encodeBool:renewable forKey:@"renewable"];
+	[aCoder encodeObject:[self verifier] forKey:@"verifier"];
 }
 
 #pragma mark duration

--- a/OAToken.m
+++ b/OAToken.m
@@ -39,7 +39,7 @@
 
 @implementation OAToken
 
-@synthesize key, secret, session, duration, attributes, forRenewal;
+@synthesize key, secret, session, duration, verifier, attributes, forRenewal;
 
 #pragma mark init
 
@@ -127,6 +127,7 @@
     self.key = nil;
     self.secret = nil;
     self.duration = nil;
+    self.verifier = nil;
     self.attributes = nil;
 	[super dealloc];
 }
@@ -230,6 +231,9 @@
 		if ([attributes count]) {
 			[params setObject:[self attributeString] forKey:@"oauth_token_attributes"];
 		}
+	}
+	if (self.verifier) {
+		[params setObject:self.verifier forKey:@"oauth_verifier"];
 	}
 	return params;
 }


### PR DESCRIPTION
First is to allow setting oauth_verifier on OAToken. This is useful for the case where you're exchanging a request token for an access token under OAuth 1.0a, which adds the "verifier" as a security measure.

Second is to make OAToken conform to NSCoding so it can be persisted to disk without using the somewhat odd user-defaults-related methods it already includes.
