### PR TITLE
Removed 4.0+ Method Call in OAMutableURLRequest

### DIFF
--- a/OAMutableURLRequest.m
+++ b/OAMutableURLRequest.m
@@ -142,6 +142,26 @@ signatureProvider:(id<OASignatureProviding>)aProvider
     nonce = (NSString *)string;
 }
 
+NSInteger normalize(id obj1, id obj2, void *context)
+{
+    NSArray *nameAndValue1 = [obj1 componentsSeparatedByString:@"="];
+    NSArray *nameAndValue2 = [obj2 componentsSeparatedByString:@"="];
+    
+    NSString *name1 = [nameAndValue1 objectAtIndex:0];
+    NSString *name2 = [nameAndValue2 objectAtIndex:0];
+    
+    NSComparisonResult comparisonResult = [name1 compare:name2];
+    if (comparisonResult == NSOrderedSame) {
+        NSString *value1 = [nameAndValue1 objectAtIndex:1];
+        NSString *value2 = [nameAndValue2 objectAtIndex:1];
+        
+        comparisonResult = [value1 compare:value2];
+    }
+    
+    return comparisonResult;
+}
+
+
 - (NSString *)_signatureBaseString {
     // OAuth Spec, Section 9.1.1 "Normalize Request Parameters"
     // build a sorted array of both request parameters and OAuth header parameters
@@ -178,24 +198,8 @@ signatureProvider:(id<OASignatureProviding>)aProvider
 		}
 	}
     
-    // Oauth Spec, Section 3.4.1.3.2 "Parameters Normalization"
-    NSArray *sortedPairs = [parameterPairs sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
-        NSArray *nameAndValue1 = [obj1 componentsSeparatedByString:@"="];
-        NSArray *nameAndValue2 = [obj2 componentsSeparatedByString:@"="];
-        
-        NSString *name1 = [nameAndValue1 objectAtIndex:0];
-        NSString *name2 = [nameAndValue2 objectAtIndex:0];
-        
-        NSComparisonResult comparisonResult = [name1 compare:name2];
-        if (comparisonResult == NSOrderedSame) {
-            NSString *value1 = [nameAndValue1 objectAtIndex:1];
-            NSString *value2 = [nameAndValue2 objectAtIndex:1];
-
-            comparisonResult = [value1 compare:value2];
-        }
-        
-        return comparisonResult;
-    }];
+    // Oauth Spec, Section 3.4.1.3.2 "Parameters Normalization    
+    NSArray *sortedPairs = [parameterPairs sortedArrayUsingFunction:normalize context:NULL];
 
     NSString *normalizedRequestParameters = [sortedPairs componentsJoinedByString:@"&"];
     [parameterPairs release];


### PR DESCRIPTION
Replaced the parameter sorting method with one compatible with 3.0+.
