### PR TITLE
Fixes for static analyzer in 4.2

### DIFF
--- a/OAMutableURLRequest.m
+++ b/OAMutableURLRequest.m
@@ -85,14 +85,10 @@ signatureProvider:(id<OASignatureProviding>)aProvider {
 signatureProvider:(id<OASignatureProviding>)aProvider
             nonce:(NSString *)aNonce
         timestamp:(NSString *)aTimestamp {
-    [self initWithURL:aUrl
-             consumer:aConsumer
-                token:aToken
-                realm:aRealm
-    signatureProvider:aProvider];
-    
-    nonce = [aNonce copy];
-    timestamp = [aTimestamp copy];
+    if ((self = [self initWithURL:aUrl consumer:aConsumer token:aToken realm:aRealm signatureProvider:aProvider])) {
+      nonce = [aNonce copy];
+      timestamp = [aTimestamp copy];
+    }
     
     return self;
 }

--- a/OAMutableURLRequest.m
+++ b/OAMutableURLRequest.m
@@ -135,7 +135,7 @@ signatureProvider:(id<OASignatureProviding>)aProvider
 - (void)_generateNonce {
     CFUUIDRef theUUID = CFUUIDCreate(NULL);
     CFStringRef string = CFUUIDCreateString(NULL, theUUID);
-    NSMakeCollectable(theUUID);
+    [NSMakeCollectable(theUUID) autorelease];
 	if (nonce) {
 		CFRelease(nonce);
 	}

--- a/OAToken.m
+++ b/OAToken.m
@@ -117,19 +117,20 @@
 }
 
 - (id)initWithUserDefaultsUsingServiceProviderName:(const NSString *)provider prefix:(const NSString *)prefix {
-	[super init];
-	self.key = [OAToken loadSetting:@"key" provider:provider prefix:prefix];
-	self.secret = [OAToken loadSetting:@"secret" provider:provider prefix:prefix];
-	self.session = [OAToken loadSetting:@"session" provider:provider prefix:prefix];
-	self.duration = [OAToken loadSetting:@"duration" provider:provider prefix:prefix];
-	self.attributes = [OAToken loadSetting:@"attributes" provider:provider prefix:prefix];
-	created = [OAToken loadSetting:@"created" provider:provider prefix:prefix];
-	renewable = [[OAToken loadSetting:@"renewable" provider:provider prefix:prefix] boolValue];
+	if ((self = [super init])) {
+      self.key = [OAToken loadSetting:@"key" provider:provider prefix:prefix];
+      self.secret = [OAToken loadSetting:@"secret" provider:provider prefix:prefix];
+      self.session = [OAToken loadSetting:@"session" provider:provider prefix:prefix];
+      self.duration = [OAToken loadSetting:@"duration" provider:provider prefix:prefix];
+      self.attributes = [OAToken loadSetting:@"attributes" provider:provider prefix:prefix];
+      created = [OAToken loadSetting:@"created" provider:provider prefix:prefix];
+      renewable = [[OAToken loadSetting:@"renewable" provider:provider prefix:prefix] boolValue];
 
-	if (![self isValid]) {
-		[self autorelease];
-		return nil;
-	}
+      if (![self isValid]) {
+        [self autorelease];
+        return nil;
+      }
+  }
 	
 	return self;
 }

--- a/OATokenManager.m
+++ b/OATokenManager.m
@@ -87,7 +87,7 @@
 
 // The application got a new authorized
 // request token and is notifying us
-- (void)authorizedToken:(const NSString *)aKey
+- (void)authorizedToken:(NSString *)aKey
 {
 	if (reqToken && [aKey isEqualToString:reqToken.key]) {
 		[self exchangeToken];

--- a/OATokenManager.m
+++ b/OATokenManager.m
@@ -282,7 +282,7 @@
 
 - (void)accessTokenReceived:(OACall *)call body:(NSString *)body
 {
-	OAToken *token = [[OAToken alloc] initWithHTTPResponseBody:body];
+	OAToken *token = [[[OAToken alloc] initWithHTTPResponseBody:body] autorelease];
 	[self setAccessToken:token];
 }
 
@@ -361,10 +361,10 @@
 - (void)fetchData:(NSString *)aURL method:(NSString *)aMethod parameters:(NSArray *)theParameters
 			files:(NSDictionary *)theFiles finished:(SEL)didFinish delegate:(NSObject*)aDelegate {
 	
-	OACall *call = [[OACall alloc] initWithURL:[NSURL URLWithString:aURL]
+	OACall *call = [[[OACall alloc] initWithURL:[NSURL URLWithString:aURL]
 										method:aMethod
 									parameters:theParameters
-										 files:theFiles];
+										 files:theFiles] autorelease];
 	NSLog(@"Received request for: %@", aURL);
 	[self enqueue:call selector:didFinish];
 	if (aDelegate) {


### PR DESCRIPTION
Here are a few commits that make the static analyzer happier in Xcode 4.2. These weren't issues in 4.1, but some new goodies in the analyzer must have found some new flags. Admittedly, some of these are somewhat stylistic, but I tend not to swim upstream against Apple's conventions.

Cheers,

—Alex V.
