### PR TITLE
got rid of xcode (4.2) warning

### DIFF
--- a/OAMutableURLRequest.m
+++ b/OAMutableURLRequest.m
@@ -138,7 +138,7 @@ signatureProvider:(id<OASignatureProviding>)aProvider
     nonce = (NSString *)string;
 }
 
-NSInteger normalize(id obj1, id obj2, void *context)
+static NSInteger normalize(id obj1, id obj2, void *context)
 {
     NSArray *nameAndValue1 = [obj1 componentsSeparatedByString:@"="];
     NSArray *nameAndValue2 = [obj2 componentsSeparatedByString:@"="];


### PR DESCRIPTION
I made the normalize function static to appease xcode.

`oauthconsumer/OAMutableURLRequest.m (141): warning: Semantic Issue: No previous prototype for function 'normalize'`
