### PR TITLE
fixed build warning in _generateTimestamp

### DIFF
--- a/OAMutableURLRequest.m
+++ b/OAMutableURLRequest.m
@@ -125,7 +125,7 @@ signatureProvider:(id<OASignatureProviding>)aProvider
 
 - (void)_generateTimestamp {
 	[timestamp release];
-    timestamp = [[NSString alloc]initWithFormat:@"%d", time(NULL)];
+    timestamp = [[NSString alloc]initWithFormat:@"%d", (unsigned int) time(NULL)];
 }
 
 - (void)_generateNonce {


### PR DESCRIPTION
cast time result to (unsigned int)
